### PR TITLE
Prefer readable identifiers from ontology over TSV.

### DIFF
--- a/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
@@ -136,7 +136,7 @@ object Generate extends Command(description = "generate ontology axioms for TSV 
   }
 
   private def readableIdentifierForIRI(iri: IRI, dosdp: ExpandedDOSDP, index: Map[IRI, Map[IRI, String]]): String = {
-    val properties = LocalLabelProperty :: dosdp.readableIdentifierProperties.map(_.getIRI)
+    val properties = dosdp.readableIdentifierProperties.map(_.getIRI) ::: LocalLabelProperty :: Nil
     val labelOpt = properties.collectFirst {
       case prop if index.get(prop).exists(_.isDefinedAt(iri)) => index(prop)(iri)
     }

--- a/src/test/resources/org/monarchinitiative/dosdp/OverrideTest.ofn
+++ b/src/test/resources/org/monarchinitiative/dosdp/OverrideTest.ofn
@@ -11,6 +11,7 @@ Ontology(<http://example.org/>
 Declaration(Class(:Entity1))
 Declaration(Class(:Entity2))
 Declaration(Class(:Entity3))
+Declaration(Class(:Entity5))
 
 
 ############################
@@ -20,6 +21,10 @@ Declaration(Class(:Entity3))
 # Class: :Entity1 (Entity 1)
 
 AnnotationAssertion(rdfs:label :Entity1 "Entity 1")
+
+# Class: :Entity5 (Entity5LabelInOnt)
+
+AnnotationAssertion(rdfs:label :Entity5 "Entity5LabelInOnt")
 
 
 )

--- a/src/test/resources/org/monarchinitiative/dosdp/OverrideTest.tsv
+++ b/src/test/resources/org/monarchinitiative/dosdp/OverrideTest.tsv
@@ -2,3 +2,5 @@ defined_class	defined_class_name	source_column	source_override	entity	entity_lab
 http://ex.org/1		source1	overridden source 1	http://example.org/Entity1
 http://ex.org/2	Entity 2 TSV	source2	    	http://example.org/Entity2
 http://ex.org/3	   	source3		http://example.org/Entity3
+http://ex.org/4	   	source4		http://example.org/Entity4	Entity4LabelInTSV
+http://ex.org/5	   	source5		http://example.org/Entity5	Entity5LabelInTSV

--- a/src/test/scala/org/monarchinitiative/dosdp/OverrideTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/OverrideTest.scala
@@ -22,12 +22,15 @@ class OverrideTest extends UnitSpec {
     axioms should contain(Class("http://ex.org/1") Annotation(RDFSLabel, "Entity 1 thing"))
     axioms should contain(Class("http://ex.org/2") Annotation(RDFSLabel, "Entity 2 TSV"))
     axioms should contain(Class("http://ex.org/3") Annotation(RDFSLabel, "http://example.org/Entity3 thing"))
+    axioms should contain(Class("http://ex.org/4") Annotation(RDFSLabel, "Entity4LabelInTSV thing"))
+    axioms should contain(Class("http://ex.org/5") Annotation(RDFSLabel, "Entity5LabelInOnt thing"))
     axioms should contain(Class("http://ex.org/1") Annotation(DCSource, "overridden source 1"))
     axioms should contain(Class("http://ex.org/2") Annotation(DCSource, "The source is source2"))
     axioms should contain(Class("http://ex.org/3") Annotation(DCSource, "The source is source3"))
 
     axioms shouldNot contain(Class("http://ex.org/2") Annotation(RDFSLabel, "Entity 2 thing"))
     axioms shouldNot contain(Class("http://ex.org/1") Annotation(DCSource, "The source is source1"))
+    axioms shouldNot contain(Class("http://ex.org/5") Annotation(RDFSLabel, "Entity5LabelInTSV thing"))
   }
 
 }


### PR DESCRIPTION
This change would take "readable identifiers" from the ontology before using a `VAR_label` column in the TSV. This way it wouldn't be a problem if labels present in the TSV get stale.