### PR TITLE
MultiClause zero2many support

### DIFF
--- a/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
@@ -3,7 +3,6 @@ package org.monarchinitiative.dosdp
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
-import cats.syntax.functor._
 import org.apache.commons.codec.digest.DigestUtils
 import org.phenoscape.scowl._
 import org.semanticweb.owlapi.model.{IRI, OWLAnnotationProperty}
@@ -176,6 +175,13 @@ final case class PrintfOWLConvenience(
                                        multi_clause: Option[MultiClausePrintf] = None) extends PrintfText {
 
   val shouldQuote = true
+
+  val allowedLogicalConnectors = List(" and ", " or ")
+
+  require(multi_clause.forall(mc => allowedLogicalConnectors.contains(mc.sep.getOrElse(""))),
+    "Only %s can be used as separator of logical expressions, but found '%s'.".format(
+      allowedLogicalConnectors.mkString("'", "', '", "'"),
+      multi_clause.flatMap(mc => mc.sep).getOrElse("")))
 
 }
 

--- a/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
@@ -135,21 +135,21 @@ object PrintfText {
     if (trimmed.isEmpty) None else Some(trimmed)
   }
 
-  private def replaceClause(printfClause: PrintfClause,bindings: Option[Map[String, Binding]], quote: Boolean): Seq[String] = {
+  private def replaceClause(printfClause: PrintfClause, bindings: Option[Map[String, Binding]], quote: Boolean): Seq[String] = {
     val singleValueBindings = bindings.getOrElse(Map.empty[String, Binding]).collect { case (key, SingleValue(value)) => (key, SingleValue(value)) }
     val clauseMultiValueBinding = bindings.getOrElse(Map.empty[String, Binding])
-          .view.filterKeys(printfClause.vars.getOrElse(List.empty).contains(_))
-          .collectFirst { case (key, MultiValue(value)) => (key, value) }
+      .view.filterKeys(printfClause.vars.getOrElse(List.empty).contains(_))
+      .collectFirst { case (key, MultiValue(value)) => (key, value) }
 
     clauseMultiValueBinding match {
-      case None        =>
+      case None                 =>
         // unpack clause to text and replace
         replaced(Some(printfClause.text), printfClause.vars, None, bindings, quote).toSeq
       case Some(multiValuePair) =>
         // unpack clause and first multi value (only one per clause supported)
         val multiValueText = for {
           value <- multiValuePair._2
-          multiText <- replaced(Some(printfClause.text), printfClause.vars, None, Some(singleValueBindings  + (multiValuePair._1 -> SingleValue(value))), quote)
+          multiText <- replaced(Some(printfClause.text), printfClause.vars, None, Some(singleValueBindings + (multiValuePair._1 -> SingleValue(value))), quote)
         } yield multiText
         multiValueText.toSeq
     }
@@ -247,8 +247,8 @@ object Annotations {
   implicit val decodeAnnotations: Decoder[Annotations] = Decoder[PrintfAnnotation].map[Annotations](identity).or(Decoder[ListAnnotation].map[Annotations](identity)).or(Decoder[IRIValueAnnotation].map[Annotations](identity))
   implicit val encodeAnnotations: Encoder[Annotations] = Encoder.instance {
     case pfa @ PrintfAnnotation(_, _, _, _, _, _) => pfa.asJson
-    case la @ ListAnnotation(_, _, _)          => la.asJson
-    case iva @ IRIValueAnnotation(_, _, _)     => iva.asJson
+    case la @ ListAnnotation(_, _, _)             => la.asJson
+    case iva @ IRIValueAnnotation(_, _, _)        => iva.asJson
   }
 
 }

--- a/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
@@ -89,7 +89,9 @@ trait PrintfText {
 
   def annotations: Option[List[Annotations]]
 
-  def replaced(bindings: Option[Map[String, SingleValue]]): Option[String] = PrintfText.replaced(this.text, this.vars, None, bindings, shouldQuote)
+  def multi_clause: Option[MultiClausePrintf]
+
+  def replaced(bindings: Option[Map[String, Binding]]): Option[String] = PrintfText.replaced(this.text, this.vars, this.multi_clause, bindings, shouldQuote)
 
   def shouldQuote: Boolean
 
@@ -97,11 +99,12 @@ trait PrintfText {
 
 object PrintfText {
 
-  def replaced(text: Option[String], vars: Option[List[String]], multi_clause: Option[MultiClausePrintf], bindings: Option[Map[String, SingleValue]], quote: Boolean): Option[String] = {
-    val replacedText = text.flatMap(content => replaceText(content, vars, bindings, quote))
+  def replaced(text: Option[String], vars: Option[List[String]], multi_clause: Option[MultiClausePrintf], bindings: Option[Map[String, Binding]], quote: Boolean): Option[String] = {
+    val singleValueBindings = bindings.map( x => x.collect { case (key, SingleValue(value)) => (key, SingleValue(value)) })
+    val replacedText = text.flatMap(content => replaceText(content, vars, singleValueBindings, quote))
     val replacedClause = multi_clause.flatMap(content => replaceMultiClause(content, bindings, quote))
     val replacedPrintf = replacedText ++ replacedClause
-    if (replacedPrintf.isEmpty) None else replacedPrintf.headOption
+    replacedPrintf.headOption
   }
 
   private def replaceText(text: String, vars: Option[List[String]], bindings: Option[Map[String, SingleValue]], quote: Boolean): Option[String] = {
@@ -120,11 +123,11 @@ object PrintfText {
     fillersOpt.getOrElse(Some(Nil)).map(fillers => text.trim().format(fillers: _*))
   }
 
-  private def replaceMultiClause(multi_clause: MultiClausePrintf, bindings: Option[Map[String, SingleValue]], quote: Boolean): Option[String] = {
+  private def replaceMultiClause(multi_clause: MultiClausePrintf, bindings: Option[Map[String, Binding]], quote: Boolean): Option[String] = {
     val replacedTexts = for {
       printfClauses <- multi_clause.clauses.toSeq
       printfClause <- printfClauses
-      printfClauseText <- replaced(Some(printfClause.text), printfClause.vars, None, bindings, quote)
+      printfClauseText <- replaceClause(printfClause, bindings, quote)
       subClauses = printfClause.sub_clauses.getOrElse(List.empty[MultiClausePrintf])
       subClausesTexts = subClauses.flatMap(mc => replaced(None, None, Some(mc), bindings, quote))
       clauseText = (printfClauseText :: subClausesTexts).mkString(multi_clause.sep.getOrElse(" "))
@@ -134,13 +137,33 @@ object PrintfText {
     if (trimmed.isEmpty) None else Some(trimmed)
   }
 
+  private def replaceClause(printfClause: PrintfClause,bindings: Option[Map[String, Binding]], quote: Boolean): Seq[String] = {
+    val singleValueBindings = bindings.getOrElse(Map.empty[String, Binding]).collect { case (key, SingleValue(value)) => (key, SingleValue(value)) }
+    val clauseMultiValueBinding = bindings.getOrElse(Map.empty[String, Binding])
+          .view.filterKeys(printfClause.vars.getOrElse(List.empty).contains(_))
+          .collectFirst { case (key, MultiValue(value)) => (key, value) }
+
+    clauseMultiValueBinding match {
+      case None        =>
+        // unpack clause to text and replace
+        replaced(Some(printfClause.text), printfClause.vars, None, bindings, quote).toSeq
+      case Some(multiValuePair) =>
+        // unpack clause and first multi value (only one per clause supported)
+        val multiValueText = for {
+          value <- multiValuePair._2
+          multiText <- replaced(Some(printfClause.text), printfClause.vars, None, Some(singleValueBindings  + (multiValuePair._1 -> SingleValue(value))), quote)
+        } yield multiText
+        multiValueText.toSeq
+    }
+  }
 }
 
 final case class PrintfOWL(
                             annotations: Option[List[Annotations]],
                             axiom_type: AxiomType,
                             text: Option[String],
-                            vars: Option[List[String]]) extends PrintfText {
+                            vars: Option[List[String]],
+                            multi_clause: Option[MultiClausePrintf] = None) extends PrintfText {
 
   val shouldQuote = true
 
@@ -149,7 +172,8 @@ final case class PrintfOWL(
 final case class PrintfOWLConvenience(
                                        annotations: Option[List[Annotations]],
                                        text: Option[String],
-                                       vars: Option[List[String]]) extends PrintfText {
+                                       vars: Option[List[String]],
+                                       multi_clause: Option[MultiClausePrintf] = None) extends PrintfText {
 
   val shouldQuote = true
 
@@ -192,7 +216,8 @@ final case class PrintfAnnotation(
                                    annotationProperty: String,
                                    text: Option[String],
                                    vars: Option[List[String]],
-                                   `override`: Option[String])
+                                   `override`: Option[String],
+                                   multi_clause: Option[MultiClausePrintf] = None)
   extends Annotations with PrintfText {
 
   val shouldQuote = false
@@ -216,7 +241,7 @@ object Annotations {
 
   implicit val decodeAnnotations: Decoder[Annotations] = Decoder[PrintfAnnotation].map[Annotations](identity).or(Decoder[ListAnnotation].map[Annotations](identity)).or(Decoder[IRIValueAnnotation].map[Annotations](identity))
   implicit val encodeAnnotations: Encoder[Annotations] = Encoder.instance {
-    case pfa @ PrintfAnnotation(_, _, _, _, _) => pfa.asJson
+    case pfa @ PrintfAnnotation(_, _, _, _, _, _) => pfa.asJson
     case la @ ListAnnotation(_, _, _)          => la.asJson
     case iva @ IRIValueAnnotation(_, _, _)     => iva.asJson
   }
@@ -230,7 +255,7 @@ final case class PrintfAnnotationOBO(
                                       xrefs: Option[String],
                                       text: Option[String],
                                       vars: Option[List[String]],
-                                      multi_clause: Option[MultiClausePrintf]) extends PrintfText with AnnotationLike with OBOAnnotations {
+                                      multi_clause: Option[MultiClausePrintf] = None) extends PrintfText with AnnotationLike with OBOAnnotations {
 
   val shouldQuote = false
 

--- a/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
@@ -99,11 +99,10 @@ trait PrintfText {
 object PrintfText {
 
   def replaced(text: Option[String], vars: Option[List[String]], multi_clause: Option[MultiClausePrintf], bindings: Option[Map[String, Binding]], quote: Boolean): Option[String] = {
-    val singleValueBindings = bindings.map( x => x.collect { case (key, SingleValue(value)) => (key, SingleValue(value)) })
+    val singleValueBindings = bindings.map(x => x.collect { case (key, SingleValue(value)) => (key, SingleValue(value)) })
     val replacedText = text.flatMap(content => replaceText(content, vars, singleValueBindings, quote))
     val replacedClause = multi_clause.flatMap(content => replaceMultiClause(content, bindings, quote))
-    val replacedPrintf = replacedText ++ replacedClause
-    replacedPrintf.headOption
+    replacedText.orElse(replacedClause)
   }
 
   private def replaceText(text: String, vars: Option[List[String]], bindings: Option[Map[String, SingleValue]], quote: Boolean): Option[String] = {

--- a/src/main/scala/org/monarchinitiative/dosdp/ExpandedDOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/ExpandedDOSDP.scala
@@ -180,7 +180,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
         trimmed = binding.trim
         if trimmed.nonEmpty
       } yield Seq(trimmed)).orElse(Some(printAnnotation(text, vars, multiClause, annotationBindings)))
-        valueOpts.getOrElse(Seq.empty).toSet[String].map(value => Annotation(subAnnotations.flatMap(translateAnnotations(_, annotationBindings, logicalBindings)), prop, value))
+      valueOpts.getOrElse(Seq.empty).toSet[String].map(value => Annotation(subAnnotations.flatMap(translateAnnotations(_, annotationBindings, logicalBindings)), prop, value))
     case NormalizedListAnnotation(prop, value, subAnnotations)                                        =>
       // If no variable bindings are passed in, dummy value is filled in using variable name
       val multiValBindingsOpt = annotationBindings.map(multiValueBindings)
@@ -203,9 +203,10 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
   /**
    * PrintfText tend to build concatenated text from multiValue bindings. But printing an annotation requires printing
    * a distinct text per multiValue item. This method enables calling PrintfText.replaced for each multiValue clause.
-   * @param text annotation text
-   * @param vars annotation variables
-   * @param multiClause annotation multiClauses
+   *
+   * @param text               annotation text
+   * @param vars               annotation variables
+   * @param multiClause        annotation multiClauses
    * @param annotationBindings variable bindings
    * @return a sequence of printed and replaced annotation texts
    */
@@ -221,12 +222,12 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
       .view.filterKeys(variables.contains(_)).collectFirst { case (key, MultiValue(value)) => (key, value) }
     val singleValBindings = annotationBindings.getOrElse(Map.empty[String, Binding]).collect { case (key, SingleValue(value)) => (key, SingleValue(value)) }
     annotationRelatedMultiValueBindings match {
-      case None =>
-        PrintfText.replaced(text, vars, multiClause, annotationBindings.map(singleValueBindings), quote=false).toSeq
+      case None                 =>
+        PrintfText.replaced(text, vars, multiClause, annotationBindings.map(singleValueBindings), quote = false).toSeq
       case Some(multiValuePair) =>
         val multiValueText = for {
           value <- multiValuePair._2
-          multiText <- PrintfText.replaced(None, None, multiClause, Some(singleValBindings + (multiValuePair._1 -> SingleValue(value))), quote=false)
+          multiText <- PrintfText.replaced(None, None, multiClause, Some(singleValBindings + (multiValuePair._1 -> SingleValue(value))), quote = false)
         } yield multiText
         multiValueText.toSeq
     }
@@ -238,12 +239,12 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
         prop <- safeChecker.getOWLAnnotationProperty(ap).toRight(DOSDPError(s"No annotation property binding: $ap"))
         annotations <- anns.to(List).flatten.map(normalizeAnnotation).sequence
       } yield NormalizedPrintfAnnotation(prop, text, vars, multiClause, overrideColumn, annotations.to(Set))
-    case ListAnnotation(anns, ap, value)                        =>
+    case ListAnnotation(anns, ap, value)                                     =>
       for {
         prop <- safeChecker.getOWLAnnotationProperty(ap).toRight(DOSDPError(s"No annotation property binding: $ap"))
         annotations <- anns.to(List).flatten.map(normalizeAnnotation).sequence
       } yield NormalizedListAnnotation(prop, value, annotations.to(Set))
-    case IRIValueAnnotation(anns, ap, varr)                     =>
+    case IRIValueAnnotation(anns, ap, varr)                                  =>
       for {
         prop <- safeChecker.getOWLAnnotationProperty(ap).toRight(DOSDPError(s"No annotation property binding: $ap"))
         annotations <- anns.to(List).flatten.map(normalizeAnnotation).sequence

--- a/src/main/scala/org/monarchinitiative/dosdp/ExpandedDOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/ExpandedDOSDP.scala
@@ -27,7 +27,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
 
   def allObjectProperties: Map[String, String] = dosdp.relations.getOrElse(Map.empty) ++ dosdp.objectProperties.getOrElse(Map.empty)
 
-  def equivalentToExpression(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
+  def equivalentToExpression(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
     val result = for {
       eq <- dosdp.equivalentTo
       ce <- expressionFor(eq, logicalBindings)
@@ -37,7 +37,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
     result.sequence
   }
 
-  def subClassOfExpression(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
+  def subClassOfExpression(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
     val result = for {
       sco <- dosdp.subClassOf
       ce <- expressionFor(sco, logicalBindings)
@@ -47,7 +47,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
     result.sequence
   }
 
-  def disjointWithExpression(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
+  def disjointWithExpression(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLClassExpression, Set[OWLAnnotation])]] = {
     val result = for {
       dw <- dosdp.disjointWith
       ce <- expressionFor(dw, logicalBindings)
@@ -57,7 +57,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
     result.sequence
   }
 
-  def gciAxiom(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLAxiom, Set[OWLAnnotation])]] =
+  def gciAxiom(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Option[(OWLAxiom, Set[OWLAnnotation])]] =
     (for {
       gci <- dosdp.GCI
       ax <- axiomFor(gci, logicalBindings)
@@ -67,7 +67,7 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
       case None                              => Right(None)
     }
 
-  def logicalAxioms(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Set[OWLAxiom]] = {
+  def logicalAxioms(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Set[OWLAxiom]] = {
     val axioms = for {
       axiomDefs <- dosdp.logical_axioms.toList
       axiomDef <- axiomDefs
@@ -86,13 +86,13 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
 
   private val term = Class(DOSDP.variableToIRI(DOSDP.DefinedClassVariable))
 
-  private def definedTerm(bindings: Option[Map[String, SingleValue]]): OWLClass = (for {
+  private def definedTerm(bindings: Option[Map[String, Binding]]): OWLClass = (for {
     actualBindings <- bindings
-    defClass <- actualBindings.get(DOSDP.DefinedClassVariable)
+    defClass <- actualBindings.collect { case (key, SingleValue(value)) => (key, SingleValue(value)) }.get(DOSDP.DefinedClassVariable)
     iri <- Prefixes.idToIRI(defClass.value, prefixes)
   } yield Class(iri)).getOrElse(term)
 
-  def filledLogicalAxioms(logicalBindings: Option[Map[String, SingleValue]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Set[OWLAxiom]] = {
+  def filledLogicalAxioms(logicalBindings: Option[Map[String, Binding]], annotationBindings: Option[Map[String, Binding]]): Either[DOSDPError, Set[OWLAxiom]] = {
     val theDefinedTerm = definedTerm(logicalBindings)
     for {
       gciAxiomOpt <- gciAxiom(logicalBindings, annotationBindings)
@@ -118,10 +118,10 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
     vars.view.mapValues(expressionParser.parse).toMap
   }
 
-  private def expressionFor(template: PrintfText, bindings: Option[Map[String, SingleValue]]): Option[OWLClassExpression] =
+  private def expressionFor(template: PrintfText, bindings: Option[Map[String, Binding]]): Option[OWLClassExpression] =
     template.replaced(bindings).map(expressionParser.parse)
 
-  private def axiomFor(template: PrintfText, bindings: Option[Map[String, SingleValue]]): Option[OWLAxiom] =
+  private def axiomFor(template: PrintfText, bindings: Option[Map[String, Binding]]): Option[OWLAxiom] =
     template.replaced(bindings).map(axiomParser.parse)
 
   private def annotationsFor(element: PrintfText, annotationBindings: Option[Map[String, Binding]], logicalBindings: Option[Map[String, Binding]]): Either[DOSDPError, Set[OWLAnnotation]] = {
@@ -173,14 +173,14 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
 
   private def translateAnnotations(annotationField: NormalizedAnnotation, annotationBindings: Option[Bindings], logicalBindings: Option[Bindings]): Set[OWLAnnotation] = annotationField match {
     case NormalizedPrintfAnnotation(prop, text, vars, multiClause, overrideColumnOpt, subAnnotations) =>
-      val valueOpt = (for {
+      val valueOpts = (for {
         column <- overrideColumnOpt
         bindings <- annotationBindings
         SingleValue(binding) <- bindings.get(column)
         trimmed = binding.trim
         if trimmed.nonEmpty
-      } yield trimmed).orElse(PrintfText.replaced(text, vars, multiClause, annotationBindings.map(singleValueBindings), false))
-      valueOpt.toSet[String].map(value => Annotation(subAnnotations.flatMap(translateAnnotations(_, annotationBindings, logicalBindings)), prop, value))
+      } yield Seq(trimmed)).orElse(Some(printAnnotation(text, vars, multiClause, annotationBindings)))
+        valueOpts.getOrElse(Seq.empty).toSet[String].map(value => Annotation(subAnnotations.flatMap(translateAnnotations(_, annotationBindings, logicalBindings)), prop, value))
     case NormalizedListAnnotation(prop, value, subAnnotations)                                        =>
       // If no variable bindings are passed in, dummy value is filled in using variable name
       val multiValBindingsOpt = annotationBindings.map(multiValueBindings)
@@ -200,12 +200,44 @@ final case class ExpandedDOSDP(dosdp: DOSDP, prefixes: PartialFunction[String, S
         iriValue))
   }
 
+  /**
+   * PrintfText tend to build concatenated text from multiValue bindings. But printing an annotation requires printing
+   * a distinct text per multiValue item. This method enables calling PrintfText.replaced for each multiValue clause.
+   * @param text annotation text
+   * @param vars annotation variables
+   * @param multiClause annotation multiClauses
+   * @param annotationBindings variable bindings
+   * @return a sequence of printed and replaced annotation texts
+   */
+  def printAnnotation(text: Option[String], vars: Option[List[String]], multiClause: Option[MultiClausePrintf], annotationBindings: Option[Bindings]): Seq[String] = {
+    val clauseVars = for {
+      mc <- multiClause.toList
+      clauses <- mc.clauses.toList
+      clause <- clauses
+      vars <- clause.vars
+    } yield vars
+    val variables = vars.getOrElse(List.empty) ++ clauseVars.flatten
+    val annotationRelatedMultiValueBindings = annotationBindings.getOrElse(Map.empty[String, Binding])
+      .view.filterKeys(variables.contains(_)).collectFirst { case (key, MultiValue(value)) => (key, value) }
+    val singleValBindings = annotationBindings.getOrElse(Map.empty[String, Binding]).collect { case (key, SingleValue(value)) => (key, SingleValue(value)) }
+    annotationRelatedMultiValueBindings match {
+      case None =>
+        PrintfText.replaced(text, vars, multiClause, annotationBindings.map(singleValueBindings), quote=false).toSeq
+      case Some(multiValuePair) =>
+        val multiValueText = for {
+          value <- multiValuePair._2
+          multiText <- PrintfText.replaced(None, None, multiClause, Some(singleValBindings + (multiValuePair._1 -> SingleValue(value))), quote=false)
+        } yield multiText
+        multiValueText.toSeq
+    }
+  }
+
   private def normalizeAnnotation(annotation: Annotations): Either[DOSDPError, NormalizedAnnotation] = annotation match {
-    case PrintfAnnotation(anns, ap, text, vars, overrideColumn) =>
+    case PrintfAnnotation(anns, ap, text, vars, overrideColumn, multiClause) =>
       for {
         prop <- safeChecker.getOWLAnnotationProperty(ap).toRight(DOSDPError(s"No annotation property binding: $ap"))
         annotations <- anns.to(List).flatten.map(normalizeAnnotation).sequence
-      } yield NormalizedPrintfAnnotation(prop, text, vars, multiClause = None, overrideColumn, annotations.to(Set))
+      } yield NormalizedPrintfAnnotation(prop, text, vars, multiClause, overrideColumn, annotations.to(Set))
     case ListAnnotation(anns, ap, value)                        =>
       for {
         prop <- safeChecker.getOWLAnnotationProperty(ap).toRight(DOSDPError(s"No annotation property binding: $ap"))

--- a/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
@@ -97,6 +97,7 @@ object Generate {
         definedClass <- maybeDefinedClass
         iriBinding = DOSDP.DefinedClassVariable -> SingleValue(definedClass)
         logicalBindings = varBindings + iriBinding
+        logicalBindingsExtended = logicalBindings ++ listVarBindings
         readableIDIndexPlusLocalLabels = readableIDIndex + localLabels
         initialAnnotationBindings = varBindings.view.mapValues(v => irisToLabels(v, eDOSDP, readableIDIndexPlusLocalLabels)).toMap ++
           listVarBindings.view.mapValues(v => irisToLabels(v, eDOSDP, readableIDIndexPlusLocalLabels)).toMap ++
@@ -111,10 +112,10 @@ object Generate {
           .getOrElse(Right((outputLogicalAxioms, outputAnnotationAxioms))).leftMap(e => DOSDPError(s"Malformed value in table restrict-axioms-column: ${e.error}"))
         (localOutputLogicalAxioms, localOutputAnnotationAxioms) = localOutputLogicalAxiomsWithLocalOutputAnnotationAxioms
         logicalAxioms <- if (localOutputLogicalAxioms)
-          eDOSDP.filledLogicalAxioms(Some(logicalBindings), Some(annotationBindings))
+          eDOSDP.filledLogicalAxioms(Some(logicalBindingsExtended), Some(annotationBindings))
         else Right(Set.empty)
         annotationAxioms <- if (localOutputAnnotationAxioms)
-          eDOSDP.filledAnnotationAxioms(Some(annotationBindings), Some(logicalBindings))
+          eDOSDP.filledAnnotationAxioms(Some(annotationBindings), Some(logicalBindingsExtended))
         else Right(Set.empty)
       } yield logicalAxioms ++ annotationAxioms
       ZIO.fromEither(maybeAxioms)

--- a/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
@@ -2,14 +2,14 @@ package org.monarchinitiative.dosdp
 
 import org.monarchinitiative.dosdp.cli.Generate
 import org.phenoscape.scowl.{not => _, _}
-import org.semanticweb.owlapi.model.{OWLAnnotationAssertionAxiom, OWLAnnotationProperty, OWLClass, OWLObjectProperty, OWLSubClassOfAxiom, OWLAxiom}
+import org.semanticweb.owlapi.model._
+import zio._
 import zio.test.Assertion._
 import zio.test._
-import zio._
 
 object MultiClausePrintfTest extends DefaultRunnableSpec {
 
-  def spec: Spec[_root_.zio.test.environment.TestEnvironment, TestFailure[Any], TestSuccess] = suite("Print simple text")(
+  def spec = suite("Print simple text")(
     test("Text should be replaced correctly") {
       val replacedText = PrintfText.replaced(Some("These cells also express %s."), Some(List("allen_makers_cat")), None, Some(Map("allen_makers_cat" -> SingleValue("my_value"))), quote = true).getOrElse("")
       assert(replacedText)(equalTo("These cells also express 'my_value'."))
@@ -34,7 +34,6 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
       assert(replacedText)(equalTo("These cells also express 'my_value'._These cells have projection type 'my_value2'."))
     },
     test("Multi_clause with three clauses, only two should replaced correctly") {
-      val test = List().mkString("z")
       val simple_clause1 = PrintfClause("These cells also express %s.", Some(List("allen_makers_cat")), None)
       val simple_clause2 = PrintfClause("These cells have projection type %s.", Some(List("not_existing_var")), None)
       val simple_clause3 = PrintfClause("These cells have some location %s.", Some(List("soma_location")), None)
@@ -291,7 +290,7 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
 
       for {
         axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(Map("defined_class" -> "ONT:0000001", "disease" -> "ONT:0000002|ONT:0000003")), None, outputLogicalAxioms = true, outputAnnotationAxioms = true, None, annotateAxiomSource = false, OboInOwlSource, generateDefinedClass = false, Map.empty)
-//        _ <- Utilities.saveAxiomsToOntology(axioms, "./dummy.owl")
+        //        _ <- Utilities.saveAxiomsToOntology(axioms, "./dummy.owl")
       } yield assert(axioms)(contains(annotationAxiom1)) &&
         assert(axioms)(contains(annotationAxiom2))
     },
@@ -299,15 +298,15 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
       var exceptionOccurred = false
 
       try {
-      val exp_clause = PrintfClause("'part_of' some %s", Some(List("item")), None)
-      val exp_printf = MultiClausePrintf(Some(" BAD_SEPARATOR "), Some(List(exp_clause)))
-      DOSDP.empty.copy(
-        pattern_name = Some("test_restrictions_pattern"),
-        classes = Some(Map("thing" -> "owl:Thing", "cell" -> "CL:0000000")),
-        relations = Some(Map("part_of" -> "BFO:0000050")),
-        list_vars = Some(Map("item" -> "'thing'")),
-        subClassOf = Some(PrintfOWLConvenience(None, None, None, Some(exp_printf)))
-      )
+        val exp_clause = PrintfClause("'part_of' some %s", Some(List("item")), None)
+        val exp_printf = MultiClausePrintf(Some(" BAD_SEPARATOR "), Some(List(exp_clause)))
+        DOSDP.empty.copy(
+          pattern_name = Some("test_restrictions_pattern"),
+          classes = Some(Map("thing" -> "owl:Thing", "cell" -> "CL:0000000")),
+          relations = Some(Map("part_of" -> "BFO:0000050")),
+          list_vars = Some(Map("item" -> "'thing'")),
+          subClassOf = Some(PrintfOWLConvenience(None, None, None, Some(exp_printf)))
+        )
       } catch {
         case e: IllegalArgumentException => exceptionOccurred = true
       }

--- a/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
@@ -1,11 +1,14 @@
 package org.monarchinitiative.dosdp
 
+import org.monarchinitiative.dosdp.cli.Generate
+import org.phenoscape.scowl.{not => _, _}
+import org.semanticweb.owlapi.model.{OWLAnnotationAssertionAxiom, OWLAnnotationProperty, OWLClass, OWLObjectProperty, OWLSubClassOfAxiom, OWLObjectUnionOf}
 import zio.test.Assertion._
 import zio.test._
 
 object MultiClausePrintfTest extends DefaultRunnableSpec {
 
-  def spec = suite("Print simple text")(
+  def spec: Spec[_root_.zio.test.environment.TestEnvironment, TestFailure[Any], TestSuccess] = suite("Print simple text")(
     test("Text should be replaced correctly") {
       val replacedText = PrintfText.replaced(Some("These cells also express %s."), Some(List("allen_makers_cat")), None, Some(Map("allen_makers_cat" -> SingleValue("my_value"))), quote = true).getOrElse("")
       assert(replacedText)(equalTo("These cells also express 'my_value'."))
@@ -31,7 +34,6 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
     },
     test("Multi_clause with three clauses, only two should replaced correctly") {
       val test = List().mkString("z")
-      println("TEST-" + test + "-")
       val simple_clause1 = PrintfClause("These cells also express %s.", Some(List("allen_makers_cat")), None)
       val simple_clause2 = PrintfClause("These cells have projection type %s.", Some(List("not_existing_var")), None)
       val simple_clause3 = PrintfClause("These cells have some location %s.", Some(List("soma_location")), None)
@@ -131,7 +133,146 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
       val replacedText = PrintfText.replaced(None, None, Some(top_printf), bindings, quote = false).getOrElse("")
 
       assert(replacedText)(equalTo("First me sibling_value1._Second me sibling_value2._Sub text1 sub_value1 end. Sub text2 sub_value2 end. Sub text3 sub_value3 end. Sub sub text1 sub_sub_value1 end. Sub sub text2 end._Third me sibling_value3."))
+    },
+    test("Multi_clause with multiValue (list_var) should replaced correctly") {
+      val simple_clause = PrintfClause("These cells also express %s.", Some(List("allen_makers_cat")), None)
+      val simple_printf = MultiClausePrintf(Some(" "), Some(List(simple_clause)))
+      val replacedText = PrintfText.replaced(None, None, Some(simple_printf), Some(Map("allen_makers_cat" -> MultiValue(Set("my_value1", "my_value2")))), quote = true).getOrElse("")
+      assert(replacedText)(equalTo("These cells also express 'my_value1'. These cells also express 'my_value2'."))
+    },
+    test("Multi_clause with two clauses (one multiValue) should replaced correctly") {
+      val simple_clause1 = PrintfClause("These cells also express %s.", Some(List("allen_makers_cat")), None)
+      val simple_clause2 = PrintfClause("These cells have projection type %s.", Some(List("projection_type")), None)
+      val simple_printf = MultiClausePrintf(Some("_"), Some(List(simple_clause1, simple_clause2)))
+      val replacedText = PrintfText.replaced(None, None, Some(simple_printf), Some(Map("allen_makers_cat" -> MultiValue(Set("my_valueX", "my_valueY")), "projection_type" -> SingleValue("my_value2"))), quote = true).getOrElse("")
+      assert(replacedText)(equalTo("These cells also express 'my_valueX'._These cells also express 'my_valueY'._These cells have projection type 'my_value2'."))
+    },
+    test("Depth2 clause nesting with a multi_value should be replaced successfully.") {
+      val sub_sub_clause1 = PrintfClause("Sub sub text1 %s end.", Some(List("sub_sub_var1")), None)
+      val sub_sub_clauses = MultiClausePrintf(Some("$"), Some(List(sub_sub_clause1)))
+
+      val sub_sub_clause2 = PrintfClause("Sub sub text2 end.", None, None)
+      val sub_sub_clauses2 = MultiClausePrintf(Some("#"), Some(List(sub_sub_clause2)))
+
+      val sub_clause1 = PrintfClause("Sub text1 %s end.", Some(List("sub_var1")), None)
+      val sub_clause2 = PrintfClause("Sub text2 %s end.", Some(List("sub_var2")), None)
+      val sub_clause3 = PrintfClause("Sub text3 %s end.", Some(List("sub_var3")), Some(List(sub_sub_clauses, sub_sub_clauses2)))
+      val sub_clauses = MultiClausePrintf(Some(" "), Some(List(sub_clause1, sub_clause2, sub_clause3)))
+
+      val sibling_clause1 = PrintfClause("First me %s.", Some(List("sibling_var1")), None)
+      val clause_with_sub = PrintfClause("Second me %s.", Some(List("sibling_var2")), Some(List(sub_clauses)))
+      val sibling_clause2 = PrintfClause("Third me %s.", Some(List("sibling_var3")), None)
+      val top_printf = MultiClausePrintf(Some("_"), Some(List(sibling_clause1, clause_with_sub, sibling_clause2)))
+
+      val bindings = Some(Map(
+        "sibling_var1" -> SingleValue("sibling_value1"),
+        "sibling_var2" -> SingleValue("sibling_value2"),
+        "sibling_var3" -> SingleValue("sibling_value3"),
+        "sub_var1" -> SingleValue("sub_value1"),
+        // and one multiValue
+        "sub_var2" -> MultiValue(Set("sub_value2_1", "sub_value2_2", "sub_value2_3")),
+        "sub_var3" -> SingleValue("sub_value3"),
+        "sub_sub_var1" -> SingleValue("sub_sub_value1")))
+
+      val replacedText = PrintfText.replaced(None, None, Some(top_printf), bindings, quote = false).getOrElse("")
+
+      assert(replacedText)(equalTo("First me sibling_value1._Second me sibling_value2._" +
+        "Sub text1 sub_value1 end. Sub text2 sub_value2_1 end. Sub text2 sub_value2_2 end. Sub text2 sub_value2_3 end. Sub text3 sub_value3 end. " +
+        "Sub sub text1 sub_sub_value1 end. Sub sub text2 end._Third me sibling_value3."))
+    },
+    testM("SubClassOf should be replaced correctly with list values (single value in it).") {
+      val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
+      val item: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
+      val partOf: OWLObjectProperty = ObjectProperty("http://purl.obolibrary.org/obo/BFO_0000050")
+      val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
+
+      val exp_clause = PrintfClause("'part_of' some %s", Some(List("item")), None)
+      val exp_printf = MultiClausePrintf(Some(" "), Some(List(exp_clause)))
+      val dosdp: DOSDP = DOSDP.empty.copy(
+        pattern_name = Some("test_restrictions_pattern"),
+        classes = Some(Map("thing" -> "owl:Thing", "cell" -> "CL:0000000")),
+        relations = Some(Map("part_of" -> "BFO:0000050")),
+        list_vars = Some(Map("item" -> "'thing'")),
+        subClassOf = Some(PrintfOWLConvenience(None, None, None, Some(exp_printf)))
+      )
+
+      val logicalAxiom1: OWLSubClassOfAxiom = term SubClassOf (partOf some item)
+
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(Map("defined_class" -> "ONT:0000001", "item" -> "ONT:0000002", "axiom_filter" -> "all")), None, outputLogicalAxioms = true, outputAnnotationAxioms = true, None, annotateAxiomSource = false, OboInOwlSource, generateDefinedClass = false, Map.empty)
+      } yield assert(axioms)(contains(logicalAxiom1))
+    },
+    testM("SubClassOf should be replaced correctly with list values (two values in it).") {
+      val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
+      val item: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
+      val item2: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000003")
+      val partOf: OWLObjectProperty = ObjectProperty("http://purl.obolibrary.org/obo/BFO_0000050")
+      val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
+
+      val exp_clause = PrintfClause("'part_of' some %s", Some(List("item")), None)
+      val exp_printf = MultiClausePrintf(Some(" and "), Some(List(exp_clause)))
+      val dosdp: DOSDP = DOSDP.empty.copy(
+        pattern_name = Some("test_restrictions_pattern"),
+        classes = Some(Map("thing" -> "owl:Thing", "cell" -> "CL:0000000")),
+        relations = Some(Map("part_of" -> "BFO:0000050")),
+        list_vars = Some(Map("item" -> "'thing'")),
+        subClassOf = Some(PrintfOWLConvenience(None, None, None, Some(exp_printf)))
+      )
+
+      val logicalAxiom1: OWLSubClassOfAxiom = term SubClassOf ((partOf some item) and (partOf some item2))
+
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(Map("defined_class" -> "ONT:0000001", "item" -> "ONT:0000002|ONT:0000003", "axiom_filter" -> "all")), None, outputLogicalAxioms = true, outputAnnotationAxioms = true, None, annotateAxiomSource = false, OboInOwlSource, generateDefinedClass = false, Map.empty)
+      } yield assert(axioms)(contains(logicalAxiom1))
+    },
+    testM("Annotation should be replaced correctly. Tests the default behaviour (without multiClauses and multiValues).") {
+      val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
+      val exacySynonym: OWLAnnotationProperty = AnnotationProperty("http://purl.obolibrary.org/obo/hasExactSynonym")
+      val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
+
+      val dosdp: DOSDP = DOSDP.empty.copy(
+        pattern_name = Some("test_restrictions_pattern"),
+        classes = Some(Map("disease" -> "MONDO:0000001")),
+        vars = Some(Map("disease" -> "''''disease'''")),
+        annotationProperties = Some(Map("exact_synonym" -> "http://purl.obolibrary.org/obo/hasExactSynonym")),
+        annotations = Some(List(PrintfAnnotation(None, "exact_synonym", Some("'%s, acute'"), Some(List("disease")), None, None)))
+      )
+
+      val annotationAxiom: OWLAnnotationAssertionAxiom = term Annotation(exacySynonym, "'http://purl.obolibrary.org/obo/ONT_0000002, acute'")
+
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(Map("defined_class" -> "ONT:0000001", "disease" -> "ONT:0000002")), None, outputLogicalAxioms = true, outputAnnotationAxioms = true, None, annotateAxiomSource = false, OboInOwlSource, generateDefinedClass = false, Map.empty)
+      } yield assert(axioms)(contains(annotationAxiom))
+    },
+    testM("Annotations should be replaced correctly with list values (two values in it).") {
+      val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
+      val item1: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
+      val item2: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000003")
+      val exacySynonym: OWLAnnotationProperty = AnnotationProperty("http://purl.obolibrary.org/obo/hasExactSynonym")
+      val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
+
+      val exp_clause = PrintfClause("'%s, acute'", Some(List("disease")), None)
+      val exp_printf = MultiClausePrintf(Some(" and "), Some(List(exp_clause)))
+      val dosdp: DOSDP = DOSDP.empty.copy(
+        pattern_name = Some("test_restrictions_pattern"),
+        classes = Some(Map("disease" -> "MONDO:0000001")),
+        list_vars = Some(Map("disease" -> "''''disease'''")),
+        annotationProperties = Some(Map("exact_synonym" -> "http://purl.obolibrary.org/obo/hasExactSynonym")),
+        annotations = Some(List(PrintfAnnotation(None, "exact_synonym", None, None, None, Some(exp_printf))))
+      )
+
+      val annotationAxiom1: OWLAnnotationAssertionAxiom = term Annotation(exacySynonym, "'http://purl.obolibrary.org/obo/ONT_0000002, acute'")
+      val annotationAxiom2: OWLAnnotationAssertionAxiom = term Annotation(exacySynonym, "'http://purl.obolibrary.org/obo/ONT_0000003, acute'")
+
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(Map("defined_class" -> "ONT:0000001", "disease" -> "ONT:0000002|ONT:0000003")), None, outputLogicalAxioms = true, outputAnnotationAxioms = true, None, annotateAxiomSource = false, OboInOwlSource, generateDefinedClass = false, Map.empty)
+//        _ <- Utilities.saveAxiomsToOntology(axioms, "./dummy.owl")
+      } yield assert(axioms)(contains(annotationAxiom1)) &&
+        assert(axioms)(contains(annotationAxiom2))
     }
+
+    // TODO: test: exceptional cases: single multiVar per multiClause, axiom sep normalization (only allow and or), GCI axiomFor testing
+
   )
 
 }

--- a/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/MultiClausePrintfTest.scala
@@ -229,11 +229,9 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
     testM("SubClassOf with annotation should be replaced correctly.") {
       val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
       val item: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
-      val partOf: OWLObjectProperty = ObjectProperty("http://purl.obolibrary.org/obo/BFO_0000050")
       val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
       val rdfsComment: OWLAnnotationProperty = AnnotationProperty("http://www.w3.org/2000/01/rdf-schema#comment")
 
-//      val annotations = Some(List(PrintfAnnotation(None, "rdfsComment", Some("%s"), Some(List("comment_var")), None, None)))
       val exp_clause = PrintfClause("%s", Some(List("comment_var")), None)
       val exp_printf = MultiClausePrintf(Some(" and "), Some(List(exp_clause)))
       val annotations = Some(List(PrintfAnnotation(None, "rdfsComment", None, None, None, Some(exp_printf))))
@@ -275,8 +273,6 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
     },
     testM("Annotations should be replaced correctly with list values (two values in it).") {
       val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
-      val item1: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
-      val item2: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000003")
       val exacySynonym: OWLAnnotationProperty = AnnotationProperty("http://purl.obolibrary.org/obo/hasExactSynonym")
       val OboInOwlSource: OWLAnnotationProperty = AnnotationProperty("http://www.geneontology.org/formats/oboInOwl#source")
 
@@ -299,9 +295,6 @@ object MultiClausePrintfTest extends DefaultRunnableSpec {
       } yield assert(axioms)(contains(annotationAxiom1)) &&
         assert(axioms)(contains(annotationAxiom2))
     },
-
-    // TODO: test: exceptional cases: single multiVar per multiClause, no nesting in axioms, axiom sep normalization (only allow and or), GCI axiomFor testing
-
     testM("Logical axiom separators should be validated. Only and, or allowed for logical expressions.") {
       var exceptionOccurred = false
 


### PR DESCRIPTION
In relation with #334, list (MultiValue) support added to multi_clause construct.

Now list_vars and data_list_vars can be used with clauses. This feature is supported in texts (def, comment, etc.), logical axioms and annotations. GCI (general class inclusion axioms) are not supported yet and not in short term plan.

Axioms supports " and ", " or " as separator and consecutively generates IntersectionOf and UnionOf constructs. When used with annotations, generates a separate axiom per list item.

Limitations (these restrictions are checked by https://github.com/INCATools/dead_simple_owl_design_patterns validator): 
- Only one list variable is supported per multi_clause.
- Nesting is not supported (and logically incorrect) for logical axioms and annotations. 

Example usage
```yaml
list_vars:
  Expresses: "'thing'"

data_list_vars:
  Expresses_pub: "xsd:string"

logical_axioms:
   - axiom_type: subClassOf
     multi_clause:
      sep: " and "
      clauses:
        - text: "'expresses' some %s"
          vars:
            - Expresses
     annotations:
       - annotationProperty: rdfsComment
         text: "%s"
         vars:
           - Expresses_comment
       - annotationProperty: hasDbXref
         multi_clause:
           sep: " "
           clauses:
             - text: '%s'
               vars:
                 - Expresses_pub
```
