### PR TITLE
Order Annotations parsers so that the different subclasses are distinguishable.

### DIFF
--- a/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/DOSDP.scala
@@ -241,7 +241,7 @@ final case class IRIValueAnnotation(
 
 object Annotations {
 
-  implicit val decodeAnnotations: Decoder[Annotations] = Decoder[PrintfAnnotation].map[Annotations](identity).or(Decoder[ListAnnotation].map[Annotations](identity)).or(Decoder[IRIValueAnnotation].map[Annotations](identity))
+  implicit val decodeAnnotations: Decoder[Annotations] = Decoder[ListAnnotation].map[Annotations](identity).or(Decoder[IRIValueAnnotation].map[Annotations](identity)).or(Decoder[PrintfAnnotation].map[Annotations](identity))
   implicit val encodeAnnotations: Encoder[Annotations] = Encoder.instance {
     case pfa @ PrintfAnnotation(_, _, _, _, _, _) => pfa.asJson
     case la @ ListAnnotation(_, _, _)             => la.asJson

--- a/src/test/resources/org/monarchinitiative/dosdp/test_annotation_parsing.yaml
+++ b/src/test/resources/org/monarchinitiative/dosdp/test_annotation_parsing.yaml
@@ -1,0 +1,45 @@
+pattern_name: plana_terms
+pattern_iri: https://tbd
+
+classes:
+  parent_entity: BFO:0000040
+  new_entity: BFO:0000040
+
+annotationProperties:
+  #  dbxref: oboInOwl:hasDbXref
+  depicted_by: foaf:depicted_by
+  image_comment: rdfs:comment
+  comment: rdfs:comment
+  has_obo_namespace: oboInOwl:hasOBONamespace
+  created_by: oboInOwl:created_by
+
+vars:
+  depicted_by: "'depicted_by'"
+  image_comment: "'image_comment'"
+  has_obo_namespace: "'has_obo_namespace'"
+  comment: "'comment'"
+  created_by: "'created_by'"
+
+data_list_vars:
+  dbxref: xsd:string
+  def_dbxref: xsd:string
+  exact_syn: xsd:string
+
+annotations:
+  - annotationProperty: depicted_by
+    var: depicted_by
+    annotations:
+      - annotationProperty: image_comment
+        text: "%s"
+        vars:
+          - image_comment
+  - annotationProperty: comment
+    text: "%s"
+    vars:
+      - comment
+  - annotationProperty: has_obo_namespace
+    text: "%s"
+    vars:
+      - has_obo_namespace
+  - annotationProperty: created_by
+    value: dbxref

--- a/src/test/scala/org/monarchinitiative/dosdp/ParseAnnotationsTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/ParseAnnotationsTest.scala
@@ -1,0 +1,24 @@
+package org.monarchinitiative.dosdp
+
+import org.monarchinitiative.dosdp.cli.Config
+import zio.logging.Logging
+import zio.test.Assertion._
+import zio.test._
+import org.monarchinitiative.dosdp.Annotations
+
+
+object ParseAnnotationsTest extends DefaultRunnableSpec {
+
+  def spec = suite("Annotations parsing") {
+    testM("Annotation types should be distinguishable") {
+      for {
+        dosdp <- Config.inputDOSDPFrom("src/test/resources/org/monarchinitiative/dosdp/test_annotation_parsing.yaml")
+        annotations = dosdp.annotations.toList.flatten
+        ann1: Annotations = IRIValueAnnotation(Some(List(PrintfAnnotation(None, "image_comment", Some("%s"), Some(List("image_comment")), None))), "depicted_by", "depicted_by")
+        ann2: Annotations = ListAnnotation(None, "created_by", "dbxref")
+        ann3: Annotations = PrintfAnnotation(None, "comment", Some("%s"), Some(List("comment")), None)
+      } yield assertTrue(annotations.contains(ann1)) && assertTrue(annotations.contains(ann2)) && assertTrue(annotations.contains(ann3))
+    }
+  }.provideCustomLayer(Logging.consoleErr())
+
+}

--- a/src/test/scala/org/monarchinitiative/dosdp/ParseAnnotationsTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/ParseAnnotationsTest.scala
@@ -2,9 +2,7 @@ package org.monarchinitiative.dosdp
 
 import org.monarchinitiative.dosdp.cli.Config
 import zio.logging.Logging
-import zio.test.Assertion._
 import zio.test._
-import org.monarchinitiative.dosdp.Annotations
 
 
 object ParseAnnotationsTest extends DefaultRunnableSpec {
@@ -13,11 +11,11 @@ object ParseAnnotationsTest extends DefaultRunnableSpec {
     testM("Annotation types should be distinguishable") {
       for {
         dosdp <- Config.inputDOSDPFrom("src/test/resources/org/monarchinitiative/dosdp/test_annotation_parsing.yaml")
-        annotations = dosdp.annotations.toList.flatten
-        ann1: Annotations = IRIValueAnnotation(Some(List(PrintfAnnotation(None, "image_comment", Some("%s"), Some(List("image_comment")), None))), "depicted_by", "depicted_by")
-        ann2: Annotations = ListAnnotation(None, "created_by", "dbxref")
-        ann3: Annotations = PrintfAnnotation(None, "comment", Some("%s"), Some(List("comment")), None)
-      } yield assertTrue(annotations.contains(ann1)) && assertTrue(annotations.contains(ann2)) && assertTrue(annotations.contains(ann3))
+        annotations = dosdp.annotations.toList.flatten.to(Set)
+        ann1 = IRIValueAnnotation(Some(List(PrintfAnnotation(None, "image_comment", Some("%s"), Some(List("image_comment")), None))), "depicted_by", "depicted_by")
+        ann2 = ListAnnotation(None, "created_by", "dbxref")
+        ann3 = PrintfAnnotation(None, "comment", Some("%s"), Some(List("comment")), None)
+      } yield assertTrue(annotations(ann1)) && assertTrue(annotations(ann2)) && assertTrue(annotations(ann3))
     }
   }.provideCustomLayer(Logging.consoleErr())
 


### PR DESCRIPTION
Fixes #404.