### PR TITLE
sbt build for Windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 enablePlugins(JavaAppPackaging)
 enablePlugins(BuildInfoPlugin)
 enablePlugins(GitVersioning)
+enablePlugins(LauncherJarPlugin)
 
 organization  := "org.monarchinitiative"
 


### PR DESCRIPTION
Steps:
- sbt build for dosdp-tools will create a dosdp-tools.bat for run the tool in Windows
- Run dosdp-tools.bat in Window

Error:
- The input line is too long

Solution: 
- You need to enable Scalar's Launcher.jar for the dosdp-tools.
- Extend build.sbt with the line enablePlugins(LauncherJarPlugin)
- See also Scalar info:  https://sbt-native-packager.readthedocs.io/en/stable/recipes/longclasspath.html#long-classpaths