### PR TITLE
Add characterization tests for generate-defined-class and substitutions

### DIFF
--- a/src/test/resources/org/monarchinitiative/dosdp/substitutions_test.ofn
+++ b/src/test/resources/org/monarchinitiative/dosdp/substitutions_test.ofn
@@ -1,0 +1,14 @@
+Prefix(:=<http://purl.obolibrary.org/obo/ONT_>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+Ontology(<http://purl.obolibrary.org/obo/substitutions_test.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/ONT_0000100>))
+Declaration(Class(<http://purl.obolibrary.org/obo/ONT_0000200>))
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ONT_0000100> "kinase activity"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ONT_0000200> "binding"^^xsd:string)
+)

--- a/src/test/scala/org/monarchinitiative/dosdp/GenerateDefinedClassTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/GenerateDefinedClassTest.scala
@@ -1,0 +1,78 @@
+package org.monarchinitiative.dosdp
+
+import org.monarchinitiative.dosdp.cli.Generate
+import org.phenoscape.scowl.{not => _, _}
+import org.semanticweb.owlapi.model.{IRI, OWLAnnotationAssertionAxiom, OWLAxiom, OWLClass, OWLObjectProperty, OWLSubClassOfAxiom}
+import zio.test.Assertion._
+import zio.test._
+import zio.logging._
+
+// Pins the --generate-defined-class IRI-minting path: when generateDefinedClass = true
+// and the row has no `defined_class` column, the defined-class IRI is computed as
+// sha1Hex(sorted-bindings) appended to the pattern IRI as a fragment. A refactor of
+// DOSDP.computeDefinedIRI or of the binding-collection that feeds it must keep the
+// same IRI shape, or every consumer that relies on these IRIs to dedupe rows breaks
+// silently.
+object GenerateDefinedClassTest extends DefaultRunnableSpec {
+
+  private val patternIRIString = "http://purl.obolibrary.org/obo/test/generate_defined_class_test.yaml"
+  private val patternIRI: IRI = IRI.create(patternIRIString)
+  private val item: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000002")
+  private val partOf: OWLObjectProperty = ObjectProperty("http://purl.obolibrary.org/obo/BFO_0000050")
+
+  private val dosdp: DOSDP = DOSDP.empty.copy(
+    pattern_name = Some("generate_defined_class_test"),
+    pattern_iri = Some(patternIRIString),
+    classes = Some(Map("thing" -> "owl:Thing")),
+    relations = Some(Map("part_of" -> "BFO:0000050")),
+    vars = Some(Map("item" -> "'thing'")),
+    name = Some(PrintfAnnotationOBO(None, None, Some("%s item"), Some(List("item")), None)),
+    subClassOf = Some(PrintfOWLConvenience(None, Some("'part_of' some %s"), Some(List("item")))))
+
+  // Mirror what Generate.renderPattern computes internally, so that the assertion
+  // would catch a behavior change in DOSDP.computeDefinedIRI itself.
+  private val expectedDefinedIRI: IRI =
+    DOSDP.computeDefinedIRI(patternIRI, Map("item" -> SingleValue("ONT:0000002")))
+  private val expectedDefinedClass: OWLClass = Class(expectedDefinedIRI)
+  private val expectedLabel: OWLAnnotationAssertionAxiom =
+    expectedDefinedClass Annotation(RDFSLabel, "http://purl.obolibrary.org/obo/ONT_0000002 item")
+  private val expectedSubClassOf: OWLSubClassOfAxiom =
+    expectedDefinedClass SubClassOf (partOf some item)
+
+  def spec = suite("generate-defined-class")(
+    testM("mints defined-class IRI from sha1 of bindings when generateDefinedClass = true") {
+      val row = Map("item" -> "ONT:0000002")
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(row), None,
+          outputLogicalAxioms = true, outputAnnotationAxioms = true, None,
+          annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+          generateDefinedClass = true, Map.empty)
+      } yield assert(axioms)(contains[OWLAxiom](expectedLabel)) &&
+        assert(axioms)(contains[OWLAxiom](expectedSubClassOf))
+    },
+    testM("with a defined_class column present, the minted IRI is used for logical axioms but the OBO `name` annotation lands on the row value") {
+      // The logical-axiom path uses the iri-binding for `defined_class`, while the OBO-style
+      // `name` rendering picks up the row's `defined_class` value before the iri-binding
+      // overrides it. If both halves of this assertion need to flip in a future change,
+      // that's the signal to update the test.
+      val row = Map("defined_class" -> "ONT:9999999", "item" -> "ONT:0000002")
+      val rowDefinedClass: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_9999999")
+      for {
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(row), None,
+          outputLogicalAxioms = true, outputAnnotationAxioms = true, None,
+          annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+          generateDefinedClass = true, Map.empty)
+      } yield assert(axioms)(contains[OWLAxiom](expectedSubClassOf)) &&
+        assert(axioms)(contains[OWLAxiom](rowDefinedClass Annotation(RDFSLabel, "http://purl.obolibrary.org/obo/ONT_0000002 item")))
+    },
+    testM("fails when pattern_iri is missing") {
+      val noIRI = dosdp.copy(pattern_iri = None)
+      val program = Generate.renderPattern(noIRI, OBOPrefixes, List(Map("item" -> "ONT:0000002")), None,
+        outputLogicalAxioms = true, outputAnnotationAxioms = true, None,
+        annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+        generateDefinedClass = true, Map.empty)
+      assertM(program.flip.map(_.msg))(containsString("generate-defined-class"))
+    }
+  ).provideCustomLayer(Logging.consoleErr())
+
+}

--- a/src/test/scala/org/monarchinitiative/dosdp/SubstitutionsTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/SubstitutionsTest.scala
@@ -1,0 +1,68 @@
+package org.monarchinitiative.dosdp
+
+import org.monarchinitiative.dosdp.cli.Generate
+import org.phenoscape.scowl.{not => _, _}
+import org.semanticweb.owlapi.model.{OWLAnnotationAssertionAxiom, OWLAxiom, OWLClass}
+import zio.test.Assertion._
+import zio.test._
+import zio.logging._
+
+// Pins the substitutions (regex sub) pipeline applied to annotation bindings.
+// RegexTest already covers ExpandedRegexSub.substitute as a unit; this fills the
+// gap on the Generate.renderPattern integration: a `substitutions` entry reads a
+// binding from `in:`, runs the regex/sub, and exposes the result under `out:` so
+// that downstream annotation templates can reference it. A non-matching value
+// must pass through unchanged.
+object SubstitutionsTest extends DefaultRunnableSpec {
+
+  private val term: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_0000001")
+
+  private val dosdp: DOSDP = DOSDP.empty.copy(
+    pattern_name = Some("substitutions_test"),
+    classes = Some(Map("thing" -> "owl:Thing")),
+    vars = Some(Map("regulated_activity" -> "'thing'")),
+    substitutions = Some(List(
+      RegexSub(in = "regulated_activity", out = "regulated_activity_munged",
+        `match` = "(.+) activity", sub = raw"\1")
+    )),
+    name = Some(PrintfAnnotationOBO(
+      annotations = None,
+      xrefs = None,
+      text = Some("regulation of %s"),
+      vars = Some(List("regulated_activity_munged"))))
+  )
+
+  def spec = suite("substitutions (regex sub) integration")(
+    testM("regex sub on a var binding feeds a downstream annotation template") {
+      // The ontology supplies a label for the filler so that the regex runs on the
+      // label "kinase activity" rather than on the raw IRI.
+      for {
+        ontology <- Utilities.loadOntology(
+          "src/test/resources/org/monarchinitiative/dosdp/substitutions_test.ofn", None)
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes,
+          List(Map("defined_class" -> "ONT:0000001", "regulated_activity" -> "ONT:0000100")),
+          Some(ontology),
+          outputLogicalAxioms = false, outputAnnotationAxioms = true, None,
+          annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+          generateDefinedClass = false, Map.empty)
+        expected: OWLAnnotationAssertionAxiom = term Annotation(RDFSLabel, "regulation of kinase")
+      } yield assert(axioms)(contains[OWLAxiom](expected))
+    },
+    testM("non-matching value passes through unchanged into the downstream template") {
+      // The label "binding" does not match "(.+) activity"; substitute returns the input,
+      // so the annotation renders with the original label.
+      for {
+        ontology <- Utilities.loadOntology(
+          "src/test/resources/org/monarchinitiative/dosdp/substitutions_test.ofn", None)
+        axioms <- Generate.renderPattern(dosdp, OBOPrefixes,
+          List(Map("defined_class" -> "ONT:0000001", "regulated_activity" -> "ONT:0000200")),
+          Some(ontology),
+          outputLogicalAxioms = false, outputAnnotationAxioms = true, None,
+          annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+          generateDefinedClass = false, Map.empty)
+        expected: OWLAnnotationAssertionAxiom = term Annotation(RDFSLabel, "regulation of binding")
+      } yield assert(axioms)(contains[OWLAxiom](expected))
+    }
+  ).provideCustomLayer(Logging.consoleErr())
+
+}


### PR DESCRIPTION
Pins two row-expansion behaviors that were not covered by the suite: the sha1-based defined-class IRI minted under --generate-defined-class, and the substitutions (RegexSub) pipeline applied to annotation bindings via Generate.renderPattern. RegexTest only covered ExpandedRegexSub.substitute as a unit.

Also pins, as a characterization, the split-IRI behavior when both --generate-defined-class and a `defined_class` column are present: logical axioms use the minted IRI while the OBO name annotation lands on the row value.