### PR TITLE
Fix split-IRI behavior when --generate-defined-class meets a defined_class column

### DIFF
--- a/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
+++ b/src/main/scala/org/monarchinitiative/dosdp/cli/Generate.scala
@@ -57,6 +57,8 @@ object Generate {
     val eDOSDP = ExpandedDOSDP(dosdp, prefixes)
     val knownColumns = dosdp.allVars
     for {
+      _ <- ZIO.when(generateDefinedClass && fillers.exists(_.contains(DOSDP.DefinedClassVariable)))(
+        logErrorFail(s"Input table must not have a '${DOSDP.DefinedClassVariable}' column when --generate-defined-class is requested."))
       permutationProperties <- eDOSDP.permutationAnnotationProperties
       permutationIndex =
         if (permutationProperties.isEmpty) Map.empty[IRI, Map[IRI, Set[String]]]
@@ -98,8 +100,10 @@ object Generate {
           function <- internalVar.apply.toSeq
           value <- function.apply(Some(dataListBindings.getOrElse(internalVar.input, listVarBindings.getOrElse(internalVar.input, MultiValue(Set.empty[String])))))
         } yield internalVar.var_name -> SingleValue(value)).toMap
+        // Exclude defined_class so the iri-binding constructed below stays authoritative
+        // for both logical and annotation axioms.
         val additionalBindings = for {
-          (key, value) <- row.view.filterKeys(k => !knownColumns(k)).toMap
+          (key, value) <- row.view.filterKeys(k => !knownColumns(k) && k != DOSDP.DefinedClassVariable).toMap
         } yield key -> SingleValue(value.trim)
         val maybeAxioms = for {
           definedClass <- if (generateDefinedClass) {

--- a/src/test/scala/org/monarchinitiative/dosdp/GenerateDefinedClassTest.scala
+++ b/src/test/scala/org/monarchinitiative/dosdp/GenerateDefinedClassTest.scala
@@ -50,20 +50,13 @@ object GenerateDefinedClassTest extends DefaultRunnableSpec {
       } yield assert(axioms)(contains[OWLAxiom](expectedLabel)) &&
         assert(axioms)(contains[OWLAxiom](expectedSubClassOf))
     },
-    testM("with a defined_class column present, the minted IRI is used for logical axioms but the OBO `name` annotation lands on the row value") {
-      // The logical-axiom path uses the iri-binding for `defined_class`, while the OBO-style
-      // `name` rendering picks up the row's `defined_class` value before the iri-binding
-      // overrides it. If both halves of this assertion need to flip in a future change,
-      // that's the signal to update the test.
+    testM("fails when the input table has a defined_class column alongside generateDefinedClass") {
       val row = Map("defined_class" -> "ONT:9999999", "item" -> "ONT:0000002")
-      val rowDefinedClass: OWLClass = Class("http://purl.obolibrary.org/obo/ONT_9999999")
-      for {
-        axioms <- Generate.renderPattern(dosdp, OBOPrefixes, List(row), None,
-          outputLogicalAxioms = true, outputAnnotationAxioms = true, None,
-          annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
-          generateDefinedClass = true, Map.empty)
-      } yield assert(axioms)(contains[OWLAxiom](expectedSubClassOf)) &&
-        assert(axioms)(contains[OWLAxiom](rowDefinedClass Annotation(RDFSLabel, "http://purl.obolibrary.org/obo/ONT_0000002 item")))
+      val program = Generate.renderPattern(dosdp, OBOPrefixes, List(row), None,
+        outputLogicalAxioms = true, outputAnnotationAxioms = true, None,
+        annotateAxiomSource = false, AxiomRestrictionsTest.OboInOwlSource,
+        generateDefinedClass = true, Map.empty)
+      assertM(program.flip.map(_.msg))(containsString(DOSDP.DefinedClassVariable))
     },
     testM("fails when pattern_iri is missing") {
       val noIRI = dosdp.copy(pattern_iri = None)


### PR DESCRIPTION
Two changes:

1. Reject the combination explicitly. When --generate-defined-class is set and the input table carries a defined_class column, renderPattern now fails with a DOSDPError naming both the flag and the column. The two together encode contradictory intent.

2. Fix the underlying bleed-through. The row's defined_class value was leaking into additionalBindings (which collects every TSV column not declared in vars/list_vars/data_vars/data_list_vars) and overriding the iri-binding for annotation axioms, so logical axioms used the minted IRI while OBO name/def/comment annotations landed on the row value. additionalBindings now excludes defined_class, making the iri-binding authoritative for both axiom kinds.

Updates GenerateDefinedClassTest: the case that previously pinned the split-IRI behavior now asserts the new error.

Fixes #508.